### PR TITLE
Fix : owner and framework data remains after leaving the page

### DIFF
--- a/src/components/common/Autocomplete.js
+++ b/src/components/common/Autocomplete.js
@@ -60,7 +60,7 @@ export const AutocompleteInput = (props) => {
             <AutocompleteTextField
               {...params}
               variant="standard"
-              helperText={props.disableValue ? "First select Language" : " "}
+              helperText={props.disableValue ? "Select Language First" : " "}
             />
           </InputFieldContainer>
         )}

--- a/src/components/step1/SelectContainer.js
+++ b/src/components/step1/SelectContainer.js
@@ -17,7 +17,7 @@ export const SelectContainer = () => {
   );
   const [frameworkOpions, setFrameworkOptions] = useState([]);
   const [isSelectLang, setIsSelectLang] = useState(false);
-  const [disableValue, setDisableValue] = useState(true);
+  const [disableValue, setDisableValue] = useState(false);
 
   // GET - Lang/Framework
   const [baseOption, setBaseOption] = useState([
@@ -31,36 +31,48 @@ export const SelectContainer = () => {
       );
 
       setBaseOption(response.data);
+      return response.data;
     } catch (e) {
       console.error(e);
     }
   }
 
+  async function getFrameworkOptionData() {
+    const data = await getBaseOptionData();
+    const selectedLanguageOption = data.find(
+      (it) => it.language === selectLang,
+    );
+    const selectedFrameworks = selectedLanguageOption.frameworks || [];
+    const selectedFrameworkNames = selectedFrameworks.map(
+      (frameworkItem) => frameworkItem.framework,
+    );
+    setFrameworkOptions(selectedFrameworkNames);
+  }
+
   useEffect(() => {
-    getBaseOptionData();
+    // isSelectLang = 0, disableValue = 0
+    if (selectLang) {
+      getFrameworkOptionData();
+    } else {
+      getBaseOptionData();
+    }
   }, []);
-  const langs = baseOption.map((it) => it.language);
 
   //Apply options based on the language of choice
   useEffect(() => {
+    // isSelectLang = 1, disableValue = 0
     if (isSelectLang) {
-      const selectedLanguageOption = baseOption.find(
-        (it) => it.language === selectLang,
-      );
-      const selectedFrameworks = selectedLanguageOption.frameworks || [];
-      const selectedFrameworkNames = selectedFrameworks.map(
-        (frameworkItem) => frameworkItem.framework,
-      );
-
-      setFrameworkOptions(selectedFrameworkNames);
-    } else {
+      getFrameworkOptionData();
       setSelectFramework("");
     }
   }, [selectLang]);
 
   useEffect(() => {
-    setSelectFramework("");
-  }, [selectLang]);
+    // isSelectLang = 0, disableValue = 1
+    if (disableValue) {
+      setSelectFramework("");
+    }
+  }, [disableValue]);
 
   return (
     <StSelectContainer container>
@@ -70,7 +82,7 @@ export const SelectContainer = () => {
       <Grid item xs={12} sm={5}>
         <AutocompleteInput
           type={"lang"}
-          options={langs}
+          options={baseOption.map((it) => it.language)}
           setIsSelectLang={setIsSelectLang}
           setDisableValue={setDisableValue}
           disableValue={false}


### PR DESCRIPTION
## Describe changes

Owner and framework data in the input field remains after leaving the page.

#### test
- [x] check if the owner data is your account as default.
owner 데이터가 기본값으로 본인 계정으로 설정되어 있는지 확인하세요.
- [x] check if changed owner data doesn't go back the default.
바뀐 owner 데이터가 기본값으로 되돌아가지 않는지 확인하세요.
- [x] check if framework options changes accord to the language data.
언어 데이터에 따라 프레임워크 옵션이 바뀌는지 확인하세요.
- [x] check if selected framework is removed when you change language.
언어를 바꾸면 선택한 프레임워크가 지워지는지 확인하세요.
- [x] check if selected framework data remains after coming back to the step1 page.
step1 페이지로 되돌아오고 선택한 프레임워크 데이터가 같은지 확인하세요.

## Issue number or link

#192 

## Types of changes

What is the type of code change?
_Put an `x` in the boxes that apply_

- [x] Bugfix (changes that resolve errors)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (big changes that affect existing functionality)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the "README.md"
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

_Please let me know if there's anything else to explain_
